### PR TITLE
Add hosted commercial companion MCP servers (Esri, Wherobots)

### DIFF
--- a/POWER.md
+++ b/POWER.md
@@ -125,6 +125,44 @@ purely as recommendations, with attribution.
     geometry ops; `geo-ops` now implements `buffer` and `convex_hull` natively,
     so `gis-mcp` is a recommended companion rather than a dependency.
 
+### Hosted, commercial MCP servers (third-party)
+
+The companions above are open-source, locally-run tools. The servers below are
+**third-party, commercial, hosted** MCP services — **not part of this Power, not
+redistributed, and not affiliated with or endorsed by AWS**. Each requires its
+own account/license. They are remote MCP endpoints (unlike the pack's local
+`uvx` servers), listed for awareness because they offer managed, at-scale
+capabilities the open servers here do not. Esri and Wherobots are members of the
+AWS Partner Network.
+
+**Esri** — two hosted MCP servers (both public beta):
+
+- **ArcGIS Enterprise MCP — public beta** — Esri's MCP server over ArcGIS
+  Enterprise content (item/layer search + describe, attribute/spatial queries,
+  map-image export, geocoding). **Beta: not GA, subject to change, not for
+  production.** Commercial; requires an ArcGIS Enterprise deployment + API key.
+  Remote HTTP, bridged into Kiro via the `mcp-remote` npx proxy with a
+  `Authorization: Bearer` header. See the
+  [ArcGIS Enterprise MCP beta docs](https://mcpbeta.webgistesting.net/mcpbetadoc/).
+- **ArcGIS Location Services MCP — public beta** — Esri's hosted MCP server over
+  the ArcGIS Location Platform:
+  geocoding, routing, elevation, and static maps. **Beta: not GA, subject to change, not for production.**
+  Commercial and metered — calls bill against ArcGIS Location Platform usage.
+  Needs a Location Platform account + an access token with beta-access and
+  Geocoding/Routing/Elevation/Static-maps privileges. Remote HTTP, bridged into
+  Kiro via the `mcp-remote` npx proxy with a `Authorization: Bearer` header. See
+  the [ArcGIS Location Services MCP docs](https://developers.arcgis.com/ai-tools/mcp-arcgis-location-services/get-started/).
+
+**Wherobots** — one hosted MCP server:
+
+- **Wherobots Cloud MCP** — managed Apache Sedona spatial lakehouse:
+  catalog exploration, planetary-scale Spatial SQL, and job submission (the
+  open, self-managed equivalent here is the EMR + Apache Sedona path in
+  `aws-geo-compute`). Commercial; the MCP server needs a Wherobots
+  Professional/Innovation/Enterprise organization. Configured with Kiro's
+  `mcpServers` `url` + `x-api-key` header schema. See the
+  [Wherobots Kiro setup docs](https://docs.wherobots.com/develop/agentic-tools/kiro).
+
 ## Cross-cutting principles
 
 - **Single credential surface** — configure keys once in `mcp.json`, each

--- a/README.md
+++ b/README.md
@@ -215,6 +215,78 @@ does not inherit your shell `PATH` and a bare `"uvx"` fails with
 Rule of thumb: use `gdal-mcp` for local/desktop file processing; use this pack
 for cloud-native reads (STAC, COG byte-range, open APIs).
 
+### Hosted, commercial MCP servers (third-party)
+
+The companions above are open-source, locally-run tools. The servers below are
+**third-party, commercial, hosted** MCP services — **not part of this Power, not
+redistributed with it, and not affiliated with or endorsed by AWS**. Each needs
+its own account/license and is configured by you. They are listed for awareness
+because they offer managed, at-scale capabilities the open servers here do not.
+Unlike the pack's local `uvx` servers, these are remote MCP endpoints. Esri and
+Wherobots are members of the AWS Partner Network.
+
+#### Esri
+
+Esri offers two hosted MCP servers (both public beta):
+
+- **ArcGIS Enterprise MCP — public beta** — Esri's MCP server over your ArcGIS
+  Enterprise content: item/layer search and describe, attribute and spatial
+  `query_data`, map-image export, and geocoding. **This is a beta — not GA; the
+  API and endpoints may change without notice, and it is not for production
+  use.** Commercial; requires an ArcGIS Enterprise deployment and an API key.
+  It is a remote HTTP endpoint; because Kiro launches MCP servers as local
+  stdio child processes, bridge to it with the `mcp-remote` npx proxy and pass
+  the key as a header (keeps the secret out of the URL):
+  ```json
+  "arcgis-enterprise": {
+    "command": "npx",
+    "args": [
+      "-y", "mcp-remote",
+      "https://<host>/<context>/platform/mcp",
+      "--header", "Authorization: Bearer <API_KEY>"
+    ]
+  }
+  ```
+  See the [ArcGIS Enterprise MCP beta docs](https://mcpbeta.webgistesting.net/mcpbetadoc/).
+
+- **ArcGIS Location Services MCP — public beta** — Esri's hosted MCP server over
+  the ArcGIS Location Platform:
+  geocoding (`find_address_candidates`, `reverse_geocode`), routing
+  (`solve_route`), elevation (`elevation_at_locations`), and static maps
+  (`map_with_points`, `map_with_polyline`). **Beta — not GA; may change without notice, not for
+  production.** Commercial and metered: every call bills against your ArcGIS
+  Location Platform usage. Requires a Location Platform account and an
+  access token with beta-access plus Geocoding/Routing/Elevation/Static-maps
+  privileges. Remote HTTP endpoint; bridge to it with the `mcp-remote` npx proxy
+  and pass the token as a Bearer header:
+  ```json
+  "arcgis-location-services": {
+    "command": "npx",
+    "args": [
+      "-y", "mcp-remote",
+      "https://location-services-mcp.arcgis.com/beta/mcp",
+      "--header", "Authorization: Bearer <ACCESS_TOKEN>"
+    ]
+  }
+  ```
+  See the [ArcGIS Location Services MCP docs](https://developers.arcgis.com/ai-tools/mcp-arcgis-location-services/get-started/).
+
+#### Wherobots
+
+- **Wherobots Cloud MCP** — a managed Apache Sedona spatial lakehouse: conversational
+  catalog exploration, planetary-scale Spatial SQL, and job submission without
+  standing up your own cluster (the open, self-managed equivalent here is the
+  EMR + Apache Sedona path in `aws-geo-compute`). Commercial; the MCP server
+  requires a Wherobots Professional, Innovation, or Enterprise organization.
+  Configured directly with Kiro's `mcpServers` `url` + header schema:
+  ```json
+  "wherobots-mcp-server": {
+    "url": "https://api.cloud.wherobots.com/mcp/",
+    "headers": { "x-api-key": "YOUR_WHEROBOTS_API_KEY" }
+  }
+  ```
+  See the [Wherobots Kiro setup docs](https://docs.wherobots.com/develop/agentic-tools/kiro).
+
 ---
 
 ## Credentials reference

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -60,6 +60,31 @@ External MCP servers (referenced / documented as companions; not redistributed)
               README.md / POWER.md; installed separately by the user under its
               own license, not bundled.
 
+  ArcGIS Enterprise MCP (public beta)    Commercial / proprietary (Esri)
+              https://mcpbeta.webgistesting.net/mcpbetadoc/
+              Documented as an optional, third-party hosted companion over the
+              user's own ArcGIS Enterprise content. Public beta (subject to
+              change, not for production). A remote MCP service the user
+              connects to with their own Esri deployment and API key; not
+              bundled, not redistributed, not affiliated with or endorsed by AWS.
+
+  ArcGIS Location Services MCP (public beta)    Commercial / proprietary (Esri)
+              https://developers.arcgis.com/ai-tools/mcp-arcgis-location-services/
+              Documented as an optional, third-party hosted companion over the
+              ArcGIS Location Platform (geocoding, routing, elevation, static
+              maps). Public beta (subject to change, not for production).
+              Commercial and metered (calls bill against ArcGIS Location Platform
+              usage). A remote MCP service the user connects to with their own
+              Esri account and access token; not bundled, not redistributed, not
+              affiliated with or endorsed by AWS.
+
+  Wherobots Cloud MCP    Commercial / proprietary (Wherobots Cloud)
+              https://docs.wherobots.com/develop/agentic-tools/kiro
+              Documented as an optional, third-party hosted companion (managed
+              Apache Sedona spatial lakehouse). A remote MCP service the user
+              connects to with their own Wherobots account; not bundled, not
+              redistributed, not affiliated with or endorsed by AWS.
+
 --------------------------------------------------------------------------------
 Data sources and model attribution
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Documents three third-party, commercial, hosted MCP servers as optional companions to the pack, grouped by provider:

- **Esri** (both public beta):
  - ArcGIS Enterprise MCP — over your own ArcGIS Enterprise content
  - ArcGIS Location Services MCP — over the ArcGIS Location Platform (geocoding, routing, elevation, static maps)
- **Wherobots**: Wherobots Cloud MCP — managed Apache Sedona spatial lakehouse

## Framing
- Each is marked third-party, commercial, bring-your-own-account, and **not affiliated with or endorsed by AWS**.
- Both Esri beta servers are clearly labeled not-GA / not-for-production.
- Includes a neutral factual note that Esri and Wherobots are members of the AWS Partner Network.
- Kiro connection guidance (mcp-remote bridge / url+header schema) included for each.

## Files
- README.md, POWER.md — new "Hosted, commercial MCP servers (third-party)" section
- THIRD-PARTY-LICENSES — matching attribution entries

Docs-only; no code or tool changes.