### PR TITLE
Expand Wherobots Cloud MCP companion description

### DIFF
--- a/POWER.md
+++ b/POWER.md
@@ -155,12 +155,15 @@ AWS Partner Network.
 
 **Wherobots** — one hosted MCP server:
 
-- **Wherobots Cloud MCP** — managed Apache Sedona spatial lakehouse:
-  catalog exploration, planetary-scale Spatial SQL, and job submission (the
-  open, self-managed equivalent here is the EMR + Apache Sedona path in
-  `aws-geo-compute`). Commercial; the MCP server needs a Wherobots
-  Professional/Innovation/Enterprise organization. Configured with Kiro's
-  `mcpServers` `url` + `x-api-key` header schema. See the
+- **Wherobots Cloud MCP** — a managed spatial lakehouse an agent drives in plain
+  language: catalog exploration, Spatial SQL or Python over planetary-scale
+  datasets, and distributed job submission, without provisioning or tuning a
+  cluster. Built for physical-world data by the original creators of Apache
+  Sedona and 100% code-compatible across every spatial function. Commercial; the
+  MCP server requires a Wherobots Professional organization (available on AWS
+  Marketplace). To self-manage the same compute, use the EMR + OSS Apache Sedona
+  path in `aws-geo-compute`. Configured with Kiro's `mcpServers` `url` +
+  `x-api-key` header schema. See the
   [Wherobots Kiro setup docs](https://docs.wherobots.com/develop/agentic-tools/kiro).
 
 ## Cross-cutting principles

--- a/README.md
+++ b/README.md
@@ -273,12 +273,16 @@ Esri offers two hosted MCP servers (both public beta):
 
 #### Wherobots
 
-- **Wherobots Cloud MCP** — a managed Apache Sedona spatial lakehouse: conversational
-  catalog exploration, planetary-scale Spatial SQL, and job submission without
-  standing up your own cluster (the open, self-managed equivalent here is the
-  EMR + Apache Sedona path in `aws-geo-compute`). Commercial; the MCP server
-  requires a Wherobots Professional, Innovation, or Enterprise organization.
-  Configured directly with Kiro's `mcpServers` `url` + header schema:
+- **Wherobots Cloud MCP** — gives an agent a managed spatial lakehouse it can
+  drive with plain language: explore a catalog, run Spatial SQL or Python over
+  planetary-scale datasets, and submit distributed jobs, all without
+  provisioning or tuning a cluster. Physical-world data is structurally different
+  from ordinary tables, and the engine underneath is built for it — by the
+  original creators of Apache Sedona and 100% code-compatible across every
+  spatial function. Commercial; the MCP server requires a Wherobots Professional
+  organization (available on AWS Marketplace). To self-manage the same compute
+  instead, use the EMR + OSS Apache Sedona path in `aws-geo-compute`. Configure
+  it in Kiro directly through the `mcpServers` `url` + header schema:
   ```json
   "wherobots-mcp-server": {
     "url": "https://api.cloud.wherobots.com/mcp/",


### PR DESCRIPTION
## Summary
Rewrites the Wherobots Cloud MCP companion entry in README.md and POWER.md with a fuller description: the agent drives a managed spatial lakehouse in plain language (catalog exploration, Spatial SQL/Python over planetary-scale data, distributed job submission) without provisioning or tuning a cluster, built by the original creators of Apache Sedona.

Also clarifies commercials: the MCP requires a Wherobots Professional organization (available on AWS Marketplace); the self-managed alternative remains the EMR + OSS Apache Sedona path in `aws-geo-compute`.

Docs-only; no code or config-schema changes. The `mcpServers` `url` + `x-api-key` config is unchanged.