### PR TITLE
docs: add Felt MCP server to hosted third-party companions

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,26 @@ Esri offers two hosted MCP servers (both public beta):
   ```
   See the [Wherobots Kiro setup docs](https://docs.wherobots.com/develop/agentic-tools/kiro).
 
+#### Felt
+
+- **Felt MCP** — gives an agent the human-facing end of the workflow: a
+  collaborative web map where the artifacts this pack produces get seen,
+  styled, and reviewed. Create and share maps; add layers from files, URLs, or
+  cloud data warehouses (Postgres/PostGIS, Snowflake, BigQuery, Redshift,
+  Databricks, SQL Server); run spatial queries against live layers; style them
+  with Felt Style Language; and drop annotations for teammates to react to —
+  the review step between an agent's output and its next iteration. Commercial
+  with a free tier; requires a Felt workspace. Remote MCP endpoint with
+  browser-based OAuth (no API keys to manage), configured in Kiro directly
+  through the `mcpServers` `url` schema:
+  ```json
+  "felt": {
+    "url": "https://felt.com/mcp"
+  }
+  ```
+  See the [Felt MCP server docs](https://help.felt.com/felt-ai/mcp).
+
+
 ---
 
 ## Credentials reference


### PR DESCRIPTION
### Description

Adds [Felt's hosted MCP server](https://help.felt.com/felt-ai/mcp) to the "Hosted, commercial MCP servers (third-party)" section of the README, alongside Esri and Wherobots.

### Motivation

The pack's three pillars end at processed artifacts — COGs, GeoParquet, embeddings, segmentation masks. The natural next step in most AIDLC loops is human review: someone looks at the output on a map, reacts, and iterates. Felt's MCP server covers that step: the agent pushes results to a shared interactive web map (layer import from files/URLs/warehouses, spatial queries, FSL styling, annotations), and a human reviews it in the browser. It chains cleanly after any Pillar B/C workflow.

Same shape as the existing hosted companions: remote MCP endpoint (`https://felt.com/mcp`) configured in Kiro via the `url` schema, OAuth in the browser, no keys to manage. Governed by its own terms; not bundled.

Disclosure: I work at Felt. Happy to adjust wording, placement, or scope however you prefer — or close if third-party additions are maintainer-only.

### Changes

- `README.md`: new `#### Felt` subsection under "Hosted, commercial MCP servers (third-party)", after Wherobots, matching the existing h4-bullet + config-snippet format (+20 lines, docs only).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.