### PR TITLE
Complete the Felt hosted-companion addition (POWER.md + licenses + partner note)

### DIFF
--- a/POWER.md
+++ b/POWER.md
@@ -132,8 +132,8 @@ The companions above are open-source, locally-run tools. The servers below are
 redistributed, and not affiliated with or endorsed by AWS**. Each requires its
 own account/license. They are remote MCP endpoints (unlike the pack's local
 `uvx` servers), listed for awareness because they offer managed, at-scale
-capabilities the open servers here do not. Esri and Wherobots are members of the
-AWS Partner Network.
+capabilities the open servers here do not. Esri, Wherobots, and Felt are members
+of the AWS Partner Network.
 
 **Esri** — two hosted MCP servers (both public beta):
 
@@ -165,6 +165,20 @@ AWS Partner Network.
   path in `aws-geo-compute`. Configured with Kiro's `mcpServers` `url` +
   `x-api-key` header schema. See the
   [Wherobots Kiro setup docs](https://docs.wherobots.com/develop/agentic-tools/kiro).
+
+**Felt** — one hosted MCP server:
+
+- **Felt MCP** — the human-facing end of the workflow: a collaborative web map
+  where the artifacts this pack produces (COGs, GeoParquet, embeddings,
+  segmentation masks) get seen, styled, and reviewed. Create/share maps; import
+  layers from files, URLs, or cloud warehouses (Postgres/PostGIS, Snowflake,
+  BigQuery, Redshift, Databricks, SQL Server); run spatial queries on live
+  layers; style with Felt Style Language; and annotate for teammates — the
+  review step between an agent's output and its next iteration. Commercial with
+  a free tier; requires a Felt workspace (available on AWS Marketplace and AWS
+  GovCloud). Remote MCP endpoint with browser-based OAuth (no keys), configured
+  with Kiro's `mcpServers` `url` schema (`https://felt.com/mcp`). See the
+  [Felt MCP server docs](https://help.felt.com/felt-ai/mcp).
 
 ## Cross-cutting principles
 

--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ The companions above are open-source, locally-run tools. The servers below are
 redistributed with it, and not affiliated with or endorsed by AWS**. Each needs
 its own account/license and is configured by you. They are listed for awareness
 because they offer managed, at-scale capabilities the open servers here do not.
-Unlike the pack's local `uvx` servers, these are remote MCP endpoints. Esri and
-Wherobots are members of the AWS Partner Network.
+Unlike the pack's local `uvx` servers, these are remote MCP endpoints. Esri,
+Wherobots, and Felt are members of the AWS Partner Network.
 
 #### Esri
 
@@ -286,6 +286,25 @@ Esri offers two hosted MCP servers (both public beta):
   }
   ```
   See the [Wherobots Kiro setup docs](https://docs.wherobots.com/develop/agentic-tools/kiro).
+
+#### Felt
+
+- **Felt MCP** — gives an agent the human-facing end of the workflow: a
+  collaborative web map where the artifacts this pack produces get seen, styled,
+  and reviewed. Create and share maps; add layers from files, URLs, or cloud
+  data warehouses (Postgres/PostGIS, Snowflake, BigQuery, Redshift, Databricks,
+  SQL Server); run spatial queries against live layers; style them with Felt
+  Style Language; and drop annotations for teammates to react to — the review
+  step between an agent's output and its next iteration. Commercial with a free
+  tier; requires a Felt workspace, and Felt is available on AWS Marketplace and
+  AWS GovCloud (US). Remote MCP endpoint with browser-based OAuth (no API keys
+  to manage), configured in Kiro directly through the `mcpServers` `url` schema:
+  ```json
+  "felt": {
+    "url": "https://felt.com/mcp"
+  }
+  ```
+  See the [Felt MCP server docs](https://help.felt.com/felt-ai/mcp).
 
 ---
 

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -96,6 +96,14 @@ External MCP servers (referenced / documented as companions; not redistributed)
               connects to with their own Wherobots account; not bundled, not
               redistributed, not affiliated with or endorsed by AWS.
 
+  Felt MCP    Commercial / proprietary (Felt)
+              https://help.felt.com/felt-ai/mcp
+              Documented as an optional, third-party hosted companion (a
+              collaborative web map for reviewing, styling, and sharing the
+              pack's outputs). A remote MCP service the user connects to with
+              their own Felt workspace (browser OAuth); not bundled, not
+              redistributed, not affiliated with or endorsed by AWS.
+
 --------------------------------------------------------------------------------
 Data sources and model attribution
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Builds on #5 by @jaime-blip (thanks!), which added **Felt** to the README's "Hosted, commercial MCP servers (third-party)" section. This adds the consistency pieces that PR didn't include, so the docs stay aligned across the repo:

### What this adds on top of #5
- **`POWER.md`** — a matching `Felt` entry under the hosted commercial companions (README and POWER.md list the same set of companions; #5 touched only README).
- **`THIRD-PARTY-LICENSES`** — a Felt entry alongside Esri/Wherobots in the "External MCP servers" section (third-party, hosted, not bundled/redistributed, not affiliated with AWS).
- **AWS Partner Network note** — adds Felt to "Esri, Wherobots, and Felt are members of the AWS Partner Network," matching how the two existing companions are framed.

### Notes
- Docs only. Felt remains a third-party, hosted, user-configured companion — not part of or redistributed with the pack, governed by its own terms.
- Suggest merging #5 first (or closing #5 in favor of this, which includes its README change) so Felt lands complete in one consistent state.
- Content mirrors the internal source-of-truth repo; will sync there once the wording is settled.