### PR TITLE
docs(accuracy): fix tool descriptions and metadata surfaced by a per-tool review

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Per-server credential keys are in the Credentials reference below.
 | 7 | `geo-ogc` | A | Open | 1 | fetch GeoJSON features from any OGC API - Features service (pygeoapi, GeoServer OGC API, ldproxy) by endpoint + collection |
 | 8 | `geo-ops` | B | Open | 7 | CRS transforms, geometry validation/ops, spatial join, overlay, buffer, convex hull, simplify (shape-preserving vertex reduction) (PyProj, Shapely/GEOS, GeoPandas) |
 | 9 | `geo-formats` | B | Open | 3 | COG / GeoParquet conversion + validation; `to_geoparquet` `src` takes inline GeoJSON **or** a path/href (local, or `s3://`/`https://` via the `[remote]` extra) so large vectors are referenced by location, not pasted inline |
-| 10 | `geo-query` | B | Open | 1 | ad-hoc, in-process spatial SQL via DuckDB Spatial (open default, opt-in `[duckdb]` extra) / Amazon Athena over S3 (bring-your-own AWS creds) — for warehouse-scale SQL see `geo-warehouse` |
+| 10 | `geo-query` | B | Open | 1 | ad-hoc, in-process spatial SQL via DuckDB Spatial (open default, opt-in `[duckdb]` extra) / Amazon Athena over S3 (bring-your-own AWS creds; Athena also requires `ATHENA_S3_STAGING_DIR`) — for warehouse-scale SQL see `geo-warehouse` |
 | 11 | `geo-raster` | B | Open | 4 | windowed COG reads (uncompressed/DEFLATE/LZW; int + float, incl. floating-point predictor) + band math (NDVI/NDWI/NBR); zonal statistics over vector zones; zonal band math (per-pixel index across separate single-band COGs, reduced per zone). Pure-Python by default; `geo-raster[fast]` adds a numpy-accelerated zonal engine |
 | 12 | `geo-pointcloud` | B | Open | 2 | Cloud-Optimized Point Cloud (COPC) read/write |
 | 13 | `geo-index` | B | Open | 1 | H3 (0-15) and S2 (0-30) spatial indexing |

--- a/packages/aws-geo-compute/aws_geo_compute/server.py
+++ b/packages/aws-geo-compute/aws_geo_compute/server.py
@@ -342,12 +342,11 @@ class AwsGeoComputeServer(BaseGeoServer):
         the provider (Req 11.3).
         """
         jobs_configured = self._jobs is not None
-        gate_configured = self._gate is not None
         specs = [
             (
                 "plan_execution",
                 OpennessTier.FREE_TIER,
-                gate_configured,
+                True,
                 "Select a processing engine from the documented decision tree "
                 "over dataset size and access pattern, and decide whether to "
                 "delegate heavy tasks to AWS compute.",

--- a/packages/geo-3d/geo_3d/server.py
+++ b/packages/geo-3d/geo_3d/server.py
@@ -64,8 +64,9 @@ class Geo3DServer(BaseGeoServer):
         (
             "points_to_3d_tiles",
             "Tile a point cloud into an OGC 3D Tiles tileset: write a "
-            "tileset.json plus a binary .pnts point-cloud tile (single root "
-            "tile; pairs with geo-pointcloud).",
+            "tileset.json plus binary .pnts point-cloud tile(s) - a single root "
+            "tile by default, or a nested octree with level-of-detail when "
+            "'max_points_per_tile' is set (pairs with geo-pointcloud).",
         ),
         (
             "dem_to_mesh",

--- a/packages/geo-foundation-models/geo_foundation_models/server.py
+++ b/packages/geo-foundation-models/geo_foundation_models/server.py
@@ -2,10 +2,13 @@
 
 This module wires the embedding core (:mod:`geo_foundation_models.embedding`)
 into the shared :class:`~geo_common.server.BaseGeoServer` contract and exposes
-``embed_tile``, ``detect_change``, and ``segment`` as MCP tools.
+its embedding, change-detection, segmentation, and published-embedding-lookup
+capabilities as MCP tools (``embed_tile``, ``embed_asset``, ``embed_assets``,
+``detect_change``, ``detect_change_from_assets``, ``change_map``, ``segment``,
+``lookup_embeddings``, ``available_embedding_periods``).
 
 It also declares the server's Resource Catalog entries (one per capability -
-Req 2.1, 11.3) and its single ``mcp.json`` credential (Req 16.1), and inherits
+Req 2.1, 11.3) and its ``mcp.json`` credentials (Req 16.1), and inherits
 the taxonomy error mapping from :class:`~geo_common.server.BaseGeoServer` so any
 library/transport/upstream failure maps onto exactly one ``Error_Taxonomy``
 category (Req 11.2, 11.5).
@@ -13,7 +16,7 @@ category (Req 11.2, 11.5).
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence
 
 from geo_common.models import (
     CatalogEntry,
@@ -88,7 +91,11 @@ class GeoFoundationModelsServer(BaseGeoServer):
 
     Holds the configurable :class:`ModelRegistry` (Clay, Prithvi-EO-2.0,
     SatCLIP and any registered additions - Requirement 9.2) and the embedding
-    backend, and registers ``embed_tile`` as an MCP tool.
+    backend, and registers the embedding, change-detection, segmentation, and
+    published-embedding-lookup tools (``embed_tile``, ``embed_asset``,
+    ``embed_assets``, ``detect_change``, ``detect_change_from_assets``,
+    ``change_map``, ``segment``, ``lookup_embeddings``,
+    ``available_embedding_periods``).
     """
 
     pillar = "C"
@@ -132,9 +139,10 @@ class GeoFoundationModelsServer(BaseGeoServer):
     def catalog_entries(self) -> "List[CatalogEntry]":
         """The Pillar C capabilities this server registers (Req 2.1, 11.3).
 
-        One :class:`~geo_common.models.CatalogEntry` per exposed tool -
-        ``embed_tile``, ``detect_change``, and ``segment`` - each naming this
-        server as ``provider_server`` (Req 11.3) and recording the entry name,
+        One :class:`~geo_common.models.CatalogEntry` per exposed tool (embedding,
+        change detection, segmentation, and published-embedding lookup) - each
+        naming this server as ``provider_server`` (Req 11.3) and recording the
+        entry name,
         pillar, capability description, and ``Openness_Tier`` required by the
         Resource Catalog (Req 2.1). The geospatial foundation models bundled
         here (Clay, Prithvi-EO-2.0, SatCLIP, SAMGeo) are openly licensed, so
@@ -281,10 +289,12 @@ class GeoFoundationModelsServer(BaseGeoServer):
     def required_credentials(self) -> "List[CredentialSpec]":
         """The ``mcp.json`` keys this server reads, with classification (Req 16.1).
 
-        Declares the single Optional ``HF_TOKEN`` (Hugging Face) credential used
-        only for gated model weights. Because it is
-        :attr:`CredentialClassification.OPTIONAL`, an absent value never blocks
-        startup (Req 16.5): openly licensed models load without it.
+        Declares two Optional keys: ``HF_TOKEN`` (Hugging Face), used only for
+        gated model weights, and ``GEO_FM_EMBED_API_KEY``, used only when a
+        remote real-weight embedding endpoint is configured. Both are
+        :attr:`CredentialClassification.OPTIONAL`, so an absent value never
+        blocks startup (Req 16.5): openly licensed models and the default
+        backend load without either.
         """
         return [
             CredentialSpec(

--- a/packages/geo-raster/geo_raster/server.py
+++ b/packages/geo-raster/geo_raster/server.py
@@ -145,8 +145,9 @@ class GeoRasterServer(BaseGeoServer):
                 capability_description=(
                     "Compute a true per-pixel band-math index (NDVI/NDWI/NBR) "
                     "across multiple single-band COGs bound to B<n> tokens, then "
-                    "reduce it to per-zone statistics (min/max/mean/sum/count) "
-                    "over vector zones in one call. Bridges indices whose bands "
+                    "reduce it to per-zone statistics (min/max/mean/sum/count/"
+                    "population standard deviation) over vector zones in one "
+                    "call. Bridges indices whose bands "
                     "live in separate assets (e.g. Sentinel-2 B08 + B04)."
                 ),
                 openness_tier=OpennessTier.OPEN,

--- a/packages/geo-warehouse/geo_warehouse/server.py
+++ b/packages/geo-warehouse/geo_warehouse/server.py
@@ -205,11 +205,14 @@ class GeoWarehouseServer(BaseGeoServer):
 def main() -> None:
     """Console entry point: serve geo-warehouse over MCP stdio.
 
-    Wires the auto-configured warehouse engines (BigQuery when
-    ``BIGQUERY_CREDENTIALS`` is set; the other engines remain inject-only), runs
-    the startup credential guard, then serves this server's registered tools
-    over stdin/stdout via the shared geo-common MCP runtime until the client
-    disconnects.
+    Wires the auto-configured warehouse engines via
+    :func:`~geo_warehouse.wiring.default_warehouse_engines` - each of BigQuery,
+    Redshift, Snowflake, and Databricks is wired when its ``mcp.json``
+    credential (``BIGQUERY_CREDENTIALS`` / ``REDSHIFT_CONNECTION`` /
+    ``SNOWFLAKE_CONNECTION`` / ``DATABRICKS_CONNECTION``) is set, and absent
+    otherwise - runs the startup credential guard, then serves this server's
+    registered tools over stdin/stdout via the shared geo-common MCP runtime
+    until the client disconnects.
     """
     from geo_warehouse.wiring import default_warehouse_engines
 


### PR DESCRIPTION
## Summary
A per-tool review (the same pass that found the geo-stac and OpenAQ issues) surfaced several documentation/metadata inaccuracies. These are **doc/description/metadata-only** — no runtime behavior change.

- **aws-geo-compute:** `plan_execution` is pure/deterministic and always available (like `select_target`), but its catalog entry set `installed=gate_configured`, mismarking a working tool as not-installed in the default wiring. Now `installed=True`; removed the now-unused `gate_configured`.
- **geo-warehouse:** `main()` docstring wrongly said only BigQuery auto-wires ("other engines remain inject-only"). `wiring.default_warehouse_engines` wires all four (BigQuery/Redshift/Snowflake/Databricks) from their credentials — docstring corrected.
- **geo-3d:** `points_to_3d_tiles` catalog description omitted the octree-LOD capability the code supports (via `max_points_per_tile`); added.
- **geo-raster:** `zonal_band_math` description listed min/max/mean/sum/count but the validator also accepts population `std`; added.
- **geo-query:** README notes Athena also requires `ATHENA_S3_STAGING_DIR` (already in the credentials table; now discoverable at the capability row).
- **geo-foundation-models:** refreshed stale prose (module/class/catalog docstrings still said "3 tools" / "single `HF_TOKEN`") to the real 9 tools + both optional keys; added a missing `Sequence` import used in a type annotation.

## Testing
`make check` (schemas + manifest) OK; affected suites: 539 passed.