### PR TITLE
docs: add Registry of Open Data on AWS (RODA) MCP server companion; bump pack to 0.3.0

### DIFF
--- a/POWER.md
+++ b/POWER.md
@@ -98,6 +98,18 @@ These are **third-party** MCP servers that pair well with this Power. They are
 you install them yourself, and each is governed by its own license. We list them
 purely as recommendations, with attribution.
 
+- **`awslabs.roda-mcp-server`** — AWS Labs' MCP server for the
+  [Registry of Open Data on AWS](https://registry.opendata.aws/)
+  ([awslabs/mcp](https://github.com/awslabs/mcp/tree/main/src/roda-mcp-server),
+  Apache-2.0). The **discovery front-door** *upstream* of this pack's
+  discover → process → analyze flow: natural-language search across 1,000+ open
+  datasets (by keyword/organization/license, always surfacing license terms),
+  public-bucket preview/sample, and `search_stac_endpoints`. Use it to *find*
+  the dataset, then read/analyze it here — its STAC-endpoint discovery pairs
+  directly with `geo-stac`, and the open datasets it surfaces (Sentinel-2 COGs,
+  etc.) are exactly what the pack's default open-data paths read.
+  - Install (separately, from PyPI): `uvx awslabs.roda-mcp-server@latest`
+
 - **`gdal-mcp`** — a GDAL/Rasterio operations MCP server
   ([JordanGunn/gdal-mcp](https://github.com/JordanGunn/gdal-mcp), MIT). It
   complements this pack's cloud-native connectors with **local-file** GDAL

--- a/README.md
+++ b/README.md
@@ -164,8 +164,23 @@ attribution.
 
 | Companion | Source | License | Use it for |
 |-----------|--------|---------|------------|
+| `awslabs.roda-mcp-server` | [awslabs/mcp](https://github.com/awslabs/mcp/tree/main/src/roda-mcp-server) | Apache-2.0 (AWS Labs) | **Discovering** open datasets on the Registry of Open Data on AWS (1,000+): search by keyword/organization/license, preview/sample public S3 buckets, and `search_stac_endpoints`. The natural discovery front-door *upstream* of this pack — find the dataset, then read/analyze it here (pairs directly with `geo-stac`) |
 | `gdal-mcp` | [JordanGunn/gdal-mcp](https://github.com/JordanGunn/gdal-mcp) | MIT | Local-file GDAL/Rasterio ops: file-level raster/vector reproject + convert, and vector `clip` (for `buffer`/`convex_hull`/`simplify` use this pack's `geo-ops`) |
 | `gis-mcp` | [mahdin75/gis-mcp](https://github.com/mahdin75/gis-mcp) | MIT | Spatial statistics / ESDA you don't get here (PySAL: Moran's I, Geary's C, Getis-Ord, LISA, spatial regression) and map rendering (static Matplotlib + interactive Folium web maps) |
+
+`awslabs.roda-mcp-server` is AWS Labs' own MCP server for the [Registry of Open
+Data on AWS](https://registry.opendata.aws/). It sits *upstream* of this pack's
+discover → process → analyze flow: use it to **find** the right open dataset
+(natural-language search across 1,000+ datasets, license always surfaced, plus
+public-bucket preview/sample), then hand the dataset's S3/STAC references to
+this pack to read and analyze cloud-natively. Its `search_stac_endpoints` tool
+pairs directly with `geo-stac`, and the open, credential-free datasets it
+surfaces (e.g. Sentinel-2 COGs) are exactly what the pack's default paths read.
+Install it separately from PyPI:
+
+```bash
+uvx awslabs.roda-mcp-server@latest
+```
 
 `gis-mcp` is a single local server built on the classic desktop Python GIS
 stack (Shapely/PyProj/GeoPandas/Rasterio/PySAL). Its **geometry, CRS, raster,

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -66,6 +66,12 @@ External MCP servers (referenced / documented as companions; not redistributed)
               map visualization); installed separately by the user under its own
               license, invoked as a separate MCP process, not bundled.
 
+  awslabs.roda-mcp-server    Apache-2.0    https://github.com/awslabs/mcp/tree/main/src/roda-mcp-server
+              AWS Labs' MCP server for the Registry of Open Data on AWS.
+              Documented as an optional companion for dataset discovery upstream
+              of this pack; installed separately by the user under its own
+              license, invoked as a separate MCP process, not bundled.
+
   gdal-mcp    MIT   https://github.com/JordanGunn/gdal-mcp
               Documented as an optional local-file GDAL/Rasterio companion in
               README.md / POWER.md; installed separately by the user under its

--- a/bundle-manifest.json
+++ b/bundle-manifest.json
@@ -1,7 +1,7 @@
 {
   "power": "kiro-geospatial",
   "displayName": "Geospatial Power Pack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A modular Kiro Power giving developers unified, AI-assisted access to the fragmented geospatial landscape across open, free-tier, and proprietary sources. Built on a dual-fragmentation framing where data access (Pillar A) and processing/compute (Pillar B) receive equal weight, plus a GeoAI pillar (Pillar C).",
   "credentialSurface": "mcp.json",
   "enums": {
@@ -20,6 +20,25 @@
   ],
   "firstExpansions": ["geo-warehouse"],
   "companions": [
+    {
+      "name": "awslabs.roda-mcp-server",
+      "relationship": "Recommended companion (AWS Labs, first-party). Not part of this Power and not redistributed with it; the user installs it separately from PyPI under its own license.",
+      "identity": "Registry of Open Data on AWS (RODA) MCP server (AWS Labs)",
+      "source": "https://github.com/awslabs/mcp/tree/main/src/roda-mcp-server",
+      "package": "awslabs.roda-mcp-server (PyPI)",
+      "license": "Apache-2.0 (the companion project's own license; see its repository)",
+      "install": "uvx awslabs.roda-mcp-server@latest",
+      "complements": "Dataset discovery upstream of this pack's discover->process->analyze flow: natural-language search across 1,000+ Registry of Open Data on AWS datasets, public S3 preview/sample, and STAC-endpoint discovery. Find the dataset with RODA, then read/analyze it cloud-natively with this pack (its search_stac_endpoints pairs directly with geo-stac).",
+      "capabilities": [
+        "search_datasets", "list_datasets", "get_dataset_details",
+        "discover_by_organization", "discover_by_license", "find_related_datasets",
+        "get_knowledge_base_stats", "preview_dataset", "sample_dataset", "search_stac_endpoints"
+      ],
+      "caveats": [
+        "Each RODA dataset has its own license terms - review them before accessing or using the data (the server always surfaces license info).",
+        "preview_dataset / sample_dataset are only available for public datasets without controlled access; other tiers may require AWS credentials (requester-pays) or additional access steps."
+      ]
+    },
     {
       "name": "gdal-mcp",
       "relationship": "Recommended companion (third-party). Not part of this Power and not redistributed with it; the user installs it separately from PyPI under its own license.",


### PR DESCRIPTION
## Summary
Adds AWS Labs' **`awslabs.roda-mcp-server`** (Apache-2.0) as a recommended open-source companion, and bumps the Power Pack version to **0.3.0**.

## Why RODA is the ideal companion
The [Registry of Open Data on AWS](https://registry.opendata.aws/) MCP server is the natural **discovery front-door** *upstream* of this pack's discover → process → analyze flow. It provides natural-language search across 1,000+ open datasets (by keyword / organization / license, always surfacing license terms), public S3 bucket preview/sample, and a `search_stac_endpoints` tool. You use RODA to **find** the dataset, then hand its S3/STAC references to this pack to read and analyze cloud-natively:
- `search_stac_endpoints` pairs directly with `geo-stac`.
- The open, credential-free datasets it surfaces (e.g. Sentinel-2 COGs) are exactly what the pack's default open-data paths read.

It is documented (not redistributed) as an open-source companion alongside `gdal-mcp` / `gis-mcp` in README, POWER.md, `bundle-manifest.json` (companions), and `THIRD-PARTY-LICENSES`. Install: `uvx awslabs.roda-mcp-server@latest`.

## Version
Pack version `bundle-manifest.json` 0.2.0 → 0.3.0. (The four servers gaining new capabilities in the sibling PRs — geo-stac, geo-weather-climate, geo-embedding-search, geo-pointcloud — are bumped to 0.3.0 within their own PRs.)

## Testing
`make check` (schemas + manifest) OK; manifest is valid JSON.
